### PR TITLE
Fix sandbox error guidance when podman is down

### DIFF
--- a/daemon_test.go
+++ b/daemon_test.go
@@ -459,8 +459,8 @@ func TestPodmanRunnerHostFallbackMustNotLeak(t *testing.T) {
 
 // TestShellCommandMustFailWithoutSandbox verifies the full tool
 // stack: when the RunShellCommand tool has a PodmanRunner with no
-// sandbox, the tool retries once (restart + retry), then returns
-// SandboxMissingError with an actionable message.
+// sandbox files, the tool retries once (restart + retry), then returns
+// SandboxSetupMissingError with an actionable message.
 func TestShellCommandMustFailWithoutSandbox(t *testing.T) {
 	cfg := &config.SandboxConfig{}
 	repoInfo := repo.RepoInfo{
@@ -484,8 +484,8 @@ func TestShellCommandMustFailWithoutSandbox(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when running shell command without sandbox, got nil — command may have run on host")
 	}
-	if !strings.Contains(err.Error(), "Sandbox container image is missing") {
-		t.Errorf("error = %q, want mention of sandbox image missing", err.Error())
+	if !strings.Contains(err.Error(), "Did you run `:init`?") {
+		t.Errorf("error = %q, want mention of :init", err.Error())
 	}
 }
 

--- a/internal/runners/image.go
+++ b/internal/runners/image.go
@@ -2,10 +2,25 @@ package runners
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os/exec"
+	"strings"
 	"time"
 )
+
+// CheckSandboxImageAvailable checks if the podman daemon is running and
+// the specified sandbox image exists. Pass the full image name
+// (e.g., "localhost/asimi-sandbox-myproject:latest").
+func CheckSandboxImageAvailable(ctx context.Context, imageName string) error {
+	cmd := exec.CommandContext(ctx, "podman", "image", "exists", imageName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return podmanImageExistsError(ctx.Err(), output, err)
+	}
+
+	return nil
+}
 
 // IsPodmanAvailable checks if podman daemon is running AND the specified sandbox image exists.
 // Pass the full image name (e.g., "localhost/asimi-sandbox-myproject:latest").
@@ -13,13 +28,45 @@ func IsPodmanAvailable(imageName string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "podman", "image", "exists", imageName)
-	err := cmd.Run()
-	if err != nil {
+	if err := CheckSandboxImageAvailable(ctx, imageName); err != nil {
 		slog.Debug("podman not available or image missing", "image", imageName, "error", err)
 		return false
 	}
 
 	slog.Debug("podman available with image", "image", imageName)
 	return true
+}
+
+func podmanImageExistsError(ctxErr error, output []byte, err error) error {
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return PodmanUnavailableError{Reason: "Podman did not respond. Start it with `podman machine start`, then try again."}
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return PodmanUnavailableError{Reason: "Podman is not installed or not on PATH. Install Podman, then run `:init`."}
+	}
+
+	message := strings.TrimSpace(string(output))
+	if isPodmanConnectionError(message) {
+		return PodmanUnavailableError{Reason: "Podman is not running. Start it with `podman machine start`, then try again."}
+	}
+
+	return SandboxMissingError{}
+}
+
+func isPodmanConnectionError(message string) bool {
+	lower := strings.ToLower(message)
+	needles := []string{
+		"cannot connect to podman",
+		"unable to connect",
+		"connection refused",
+		"podman machine",
+		"podman.sock",
+		"no such file or directory",
+	}
+	for _, needle := range needles {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/runners/image_test.go
+++ b/internal/runners/image_test.go
@@ -1,0 +1,61 @@
+package runners
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestPodmanImageExistsErrorPodmanMachineDown(t *testing.T) {
+	err := podmanImageExistsError(nil, []byte("Cannot connect to Podman. try `podman machine start`"), errors.New("exit status 125"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(PodmanUnavailableError); !ok {
+		t.Fatalf("error = %T, want PodmanUnavailableError", err)
+	}
+	if !strings.Contains(err.Error(), "podman machine start") {
+		t.Fatalf("error = %q, want podman machine start guidance", err)
+	}
+}
+
+func TestPodmanImageExistsErrorMissingImage(t *testing.T) {
+	err := podmanImageExistsError(nil, nil, errors.New("exit status 1"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(SandboxMissingError); !ok {
+		t.Fatalf("error = %T, want SandboxMissingError", err)
+	}
+	if !strings.Contains(err.Error(), "just build-sandbox") {
+		t.Fatalf("error = %q, want build-sandbox guidance", err)
+	}
+}
+
+func TestPodmanImageExistsErrorPodmanTimeout(t *testing.T) {
+	err := podmanImageExistsError(context.DeadlineExceeded, nil, context.DeadlineExceeded)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(PodmanUnavailableError); !ok {
+		t.Fatalf("error = %T, want PodmanUnavailableError", err)
+	}
+	if !strings.Contains(err.Error(), "podman machine start") {
+		t.Fatalf("error = %q, want podman machine start guidance", err)
+	}
+}
+
+func TestPodmanImageExistsErrorPodmanMissing(t *testing.T) {
+	err := podmanImageExistsError(nil, nil, exec.ErrNotFound)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(PodmanUnavailableError); !ok {
+		t.Fatalf("error = %T, want PodmanUnavailableError", err)
+	}
+	if !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("error = %q, want install guidance", err)
+	}
+}

--- a/internal/runners/podman.go
+++ b/internal/runners/podman.go
@@ -81,7 +81,14 @@ func (r *PodmanRunner) initialize(ctx context.Context) error {
 
 	r.mu.Lock()
 	hasConnection := r.conn != nil
+	containerStarted := r.containerStarted
 	r.mu.Unlock()
+
+	if !hasConnection || !containerStarted {
+		if err := r.preflightSandbox(ctx); err != nil {
+			return err
+		}
+	}
 
 	if !hasConnection {
 		slog.Debug("establishing podman connection")
@@ -189,6 +196,46 @@ func (r *PodmanRunner) initialize(ctx context.Context) error {
 
 	slog.Debug("initialization complete")
 	return nil
+}
+
+func (r *PodmanRunner) preflightSandbox(ctx context.Context) error {
+	if err := r.checkSandboxFiles(); err != nil {
+		return err
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return CheckSandboxImageAvailable(probeCtx, r.imageName)
+}
+
+func (r *PodmanRunner) checkSandboxFiles() error {
+	root := r.projectWorkingRoot()
+	if root == "" {
+		return nil
+	}
+
+	required := []string{
+		".agents/sandbox",
+		".agents/sandbox/Dockerfile",
+		".agents/sandbox/bashrc",
+	}
+	for _, rel := range required {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			return SandboxSetupMissingError{}
+		}
+	}
+
+	return nil
+}
+
+func (r *PodmanRunner) projectWorkingRoot() string {
+	if r.repoInfo.ProjectRoot == "" {
+		return ""
+	}
+	if r.repoInfo.WorktreePath != "" {
+		return filepath.Join(r.repoInfo.ProjectRoot, r.repoInfo.WorktreePath)
+	}
+	return r.repoInfo.ProjectRoot
 }
 
 func (r *PodmanRunner) establishConnection(ctx context.Context) (context.Context, error) {
@@ -393,7 +440,7 @@ func (r *PodmanRunner) Run(ctx context.Context, input Input) (Output, error) {
 			out, fallbackErr := r.fallback.Run(ctx, input)
 			return out, SandboxFallbackError{Err: err, FallbackErr: fallbackErr}
 		}
-		return Output{}, SandboxMissingError{}
+		return Output{}, err
 	}
 
 	r.outputsMu.Lock()

--- a/internal/runners/runner.go
+++ b/internal/runners/runner.go
@@ -106,11 +106,18 @@ func (e PodmanUnavailableError) Error() string {
 	return e.Reason
 }
 
-// SandboxMissingError is returned when the sandbox image is missing
+// SandboxSetupMissingError is returned when project sandbox files are missing.
+type SandboxSetupMissingError struct{}
+
+func (e SandboxSetupMissingError) Error() string {
+	return "Sandbox files are missing. Did you run `:init`?"
+}
+
+// SandboxMissingError is returned when the sandbox image is missing.
 type SandboxMissingError struct{}
 
 func (e SandboxMissingError) Error() string {
-	return "Sandbox container image is missing. Did you run `:init` ?"
+	return "Sandbox container image is missing. Please run `just build-sandbox`."
 }
 
 // SandboxFallbackError is returned when a command fell back to the


### PR DESCRIPTION
## Summary
- split sandbox setup, podman availability, and sandbox image errors before starting the podman runner
- keep `:init` guidance for missing `.agents/sandbox` files
- show `podman machine start` guidance when podman is unreachable, and `just build-sandbox` when only the image is missing

Fixes #131

## Validation
- `go test -tags containers_image_openpgp -run 'TestPodmanImageExistsError|TestPodmanRunnerWithFallback|TestNewPodmanRunner' ./internal/runners` - passed\n- `go test -tags containers_image_openpgp -run TestShellCommandMustFailWithoutSandbox .` - passed\n- `go test -tags containers_image_openpgp -timeout 1m ./...` - passed\n- `go build -tags containers_image_openpgp -o /tmp/asimi-cli-opp138 .` - passed\n- `git diff --check` - passed\n- `git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` - passed\n\nNot run locally:\n- untagged `go test`/`go build` because `gpgme.pc` is missing from this machine\n- `just lint` because `golangci-lint` is not installed\n- `just fmt` because `goimports` is not installed; changed files were formatted with `gofmt`