### PR TITLE
fix: show shell given progress in rituals

### DIFF
--- a/shogunate/ritual.go
+++ b/shogunate/ritual.go
@@ -971,9 +971,23 @@ func (r *RitualRunner) executeStep(ctx context.Context, exec *RitualExecution, s
 			if err != nil {
 				return "", fmt.Errorf("given %q failed: %w", raw, err)
 			}
+			if entry.Kind == StepDefBash {
+				exec.Notify(RitualStepMsg{
+					StepName: entry.Key,
+					Status:   "cmd_running",
+					Message:  raw,
+				})
+			}
 			result, err := r.runGivenStep(ctx, exec, entry)
 			if err != nil {
 				return "", fmt.Errorf("given %q failed: %w", raw, err)
+			}
+			if entry.Kind == StepDefBash {
+				exec.Notify(RitualStepMsg{
+					StepName: entry.Key,
+					Status:   "cmd_done",
+					Message:  raw,
+				})
 			}
 			storeGivenResult(exec, entry.Key, result)
 		}

--- a/shogunate/ritual_test.go
+++ b/shogunate/ritual_test.go
@@ -1084,6 +1084,77 @@ func TestBackgroundGiven(t *testing.T) {
 	}
 }
 
+func TestStepGivenBashNotifications(t *testing.T) {
+	db := setupRitualTestDB(t)
+
+	ritual := &RitualDef{
+		Name: "given-bash-notify",
+		Steps: []RitualStep{
+			{
+				Name:     "work",
+				Minister: "forge",
+				Given:    []string{"!echo given-data"},
+				Task:     "do work",
+			},
+		},
+	}
+
+	registry := NewRitualRegistry()
+	registry.Register(ritual)
+
+	shogunate := newRitualTestShogunate(t, "step-done\n", nil)
+	mockRunner := &mockCallCountRunner{
+		results: []runners.Output{
+			{Output: "given-data\n", ExitCode: "0"},
+		},
+	}
+	runner := NewRitualRunner(registry, shogunate.GetMinister, shogunate.PublishEvent, db, mockRunner, nil)
+
+	var messages []RitualStepMsg
+	notify := func(msg any) {
+		if stepMsg, ok := msg.(RitualStepMsg); ok {
+			messages = append(messages, stepMsg)
+		}
+	}
+
+	ctx := context.Background()
+	exec, err := runner.Start(ctx, "given-bash-notify", testEK(10), nil, notify)
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+
+	err = runner.Run(ctx, exec)
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	if got := exec.Data["echo"]; got != "given-data\n" {
+		t.Errorf("expected given result to be stored under echo, got %q", got)
+	}
+
+	var cmdStatuses []string
+	for _, m := range messages {
+		if m.Message != "!echo given-data" {
+			continue
+		}
+		cmdStatuses = append(cmdStatuses, m.Status)
+		if m.StepName != "echo" {
+			t.Errorf("expected command notification step name 'echo', got %q", m.StepName)
+		}
+	}
+
+	expected := []string{"cmd_running", "cmd_done"}
+	if len(cmdStatuses) != len(expected) {
+		t.Fatalf("expected command statuses %v, got %v", expected, cmdStatuses)
+	}
+	for i := range expected {
+		if cmdStatuses[i] != expected[i] {
+			t.Errorf("expected command statuses %v, got %v", expected, cmdStatuses)
+			break
+		}
+	}
+}
+
 // ritualTestMinister is a Minister that auto-completes tasks with a configured result.
 type ritualTestMinister struct {
 	MinisterBase
@@ -1100,7 +1171,7 @@ func (m *ritualTestMinister) SystemPrompt() string        { return "" }
 func (m *ritualTestMinister) Title() string               { return m.id }
 func (m *ritualTestMinister) Tools() []Tool               { return nil }
 func (m *ritualTestMinister) Tasks() chan<- *Task         { return m.tasksCh }
-func (m *ritualTestMinister) Model() LLMProvider     { return nil }
+func (m *ritualTestMinister) Model() LLMProvider          { return nil }
 func (m *ritualTestMinister) GetConfig() config.LLMConfig { return config.LLMConfig{} }
 func (m *ritualTestMinister) Run(ctx context.Context) {
 	for {


### PR DESCRIPTION
Adds the same shell-command progress messages for step-level `given` entries that already exist for background context and `then` steps.

When a ritual step has `given: ["!..."]`, the runner now emits `cmd_running` before executing the shell command and `cmd_done` after it succeeds, so the TUI can display the command instead of silently waiting. The command output is still stored in the same execution context key, so later template expansion and minister execution semantics are unchanged.

A focused regression test covers a minister step with a shell `given`, checks the `cmd_running` → `cmd_done` order, and verifies the command result remains available in `exec.Data`.

Fixes #132

## Validation

- `gofmt -w shogunate/ritual.go shogunate/ritual_test.go`
- `git diff --check`
- `GOTOOLCHAIN=go1.26.2 go test ./shogunate -run 'Test(StepGivenBashNotifications|BackgroundGiven|RitualStreamMessages|RunGivenStep_Bash|RunThenStep_Bash)$' -count=1` currently fails before tests run because the checked-in vendor tree references removed `github.com/cyphar/filepath-securejoin` wrappers from `go.podman.io/storage`. The same unrelated vendor build failure is already present on `main` CI: https://github.com/afittestide/asimi-cli/actions/runs/26384224609
