### PR TITLE
bug: fixing missing pkg-config/gpgme in bootstrap

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -61,6 +61,7 @@ clean:
 bootstrap:
     go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     go install golang.org/x/tools/cmd/goimports@latest
+    brew install pkg-config gpgme
 
 # Init and start the podman machine 
 init-podman:

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ ASIMI_LOOPBACK=1 just run
 
 - Go 1.25 or higher
 - `just bootstrap`
+- `pkg-config` and `gpgme` (macOS: `brew install pkg-config gpgme`) — required to
+  build the `podman`/`gpgme` cgo dependency; installed automatically by
+  `just bootstrap`
 
 ### Common Tasks
 


### PR DESCRIPTION
## What broke

`just build` / `go build -o asimi .` failed with:
```
github.com/proglottis/gpgme: exec: "pkg-config": executable file not found in $PATH
```

## Why

`internal/runners` depends on `podman/v5`'s `specgen` package (used for Asimi's
sandbox container support), which pulls in `go.podman.io/common/libimage` ->
`go.podman.io/image/v5/signature` -> `github.com/proglottis/gpgme` (confirmed via
`go mod why github.com/proglottis/gpgme`). That package uses cgo to bind against
the system `libgpgme` library, so building it requires `pkg-config` on `$PATH`
plus the `gpgme` headers/library - neither ships with a default Go/macOS setup,
and `just bootstrap` only installed `golangci-lint` and `goimports`, so nothing
in the contributor flow covered this native dependency.

On my machine this was compounded by a pre-existing Homebrew ownership issue:
several `/usr/local/Cellar` directories were owned by a different local uid with
no group-write bit, blocking `brew install gpgme` until I ran
`sudo chown -R $(whoami):admin /usr/local/Cellar ...` - that part is
system-specific and not part of this fix, just noted here for context on why
the repro took a couple of steps to fully unblock.

## Fix

- Justfile: bootstrap now also runs `brew install pkg-config gpgme`, so a
  fresh macOS contributor setup covers this cgo dependency.
- README.md: Prerequisites section now documents pkg-config/gpgme as required
  to build the podman/gpgme cgo dependency.